### PR TITLE
[FIX][DM-562] Allow JSON GET request to not specify body

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -610,7 +610,7 @@ class JsonRequest(WebRequest):
 
         # Read POST content or POST Form Data named "request"
         try:
-            self.jsonrequest = json.loads(request)
+            self.jsonrequest = json.loads(request) if request else json.loads('{}')
         except ValueError:
             msg = 'Invalid JSON data: %r' % (request,)
             _logger.info('%s: %s', self.httprequest.path, msg)


### PR DESCRIPTION
Currently Odoo assumes that a request body is set for any JSON API requests, even though this is not required. See "params" here: https://www.jsonrpc.org/specification#request_object

This change will set the request body to be empty if not set, as Odoo did allow for JSON API GET requests to be sent with an empty body set. This allows external services to make JSON API GET requests without needing to specify a body, something which some applications do not allow.