### PR TITLE
[IMP][DM-614] Force worker exit when memory limit exceeded with no requests

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -844,6 +844,10 @@ class Worker(object):
             _logger.info("Worker (%s) exiting. request_count: %s, registry count: %s.",
                          self.pid, self.request_count,
                          len(odoo.modules.registry.Registry.registries))
+            if self.request_count == 0:
+                # Worker has exceeded memory limit without processing any requests
+                # raise an exception to force it to exit and clear memory
+                raise Exception("Worker (%s) exited without processing any requests" % self.pid)
             self.stop()
         except Exception:
             _logger.exception("Worker (%s) Exception occured, exiting..." % self.pid)


### PR DESCRIPTION
* There has been instances where an Odoo worker has exceeded the soft memory limit after a low level error (e.g. PSQL constraint) the new worker created carried over the same virtual memory
* The above meant that the worker was killed instantly and this would repeat until the workers were manually killed and Odoo restarted
* By raising an exception in this case, the Odoo worker will explicitly exit, with the new worker being created without carrying over any reserved memory